### PR TITLE
新規投稿スタイルカテゴリ追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -612,6 +612,7 @@ h3 {
     flex-wrap: wrap;
     gap: 14px 22px;
     margin-top: 6px;
+    justify-content: center;
 }
 
 .category-chip {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,6 +2,8 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    @post.style_category = current_user.style_category
+    @post.height_range = current_user.height_range
     @categories = Category.order(:name)
   end
 
@@ -45,6 +47,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :body, :image, :original_image_url, :adjusted_image_url, :brightness_level, category_ids: [])
+    params.require(:post).permit(:title, :body, :image, :original_image_url, :adjusted_image_url, :brightness_level, :style_category, :height_range, category_ids: [])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+
+  def enum_display_name(model, attribute, value)
+    t("activerecord.attributes.#{model.model_name.i18n_key}.#{attribute}.#{value}")
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,4 +8,8 @@ class Post < ApplicationRecord
   validates :brightness_level, inclusion: { in: 0..100 }
 
   has_one_attached :image
+
+  enum :style_category, User.style_categories
+  enum :height_range, User.height_ranges
+
 end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -68,6 +68,38 @@
         </div>
     </div>
 
+    <div class="category-area">
+        <div class="category-header">
+            <span class="category-title">骨格</span>
+        </div>
+        <div class="category-list">
+            <% User.style_categories.each_key do |key| %>
+                <label class="category-chip">
+                    <%= f.radio_button :style_category, key, class: "category-checkbox" %>
+                    <span class="category-pill">
+                        <%= enum_display_name(@post, :style_category, key) %>
+                    </span>
+                </label>
+            <% end %>
+        </div>
+    </div>
+
+    <div class="category-area">
+        <div class="category-header">
+            <span class="category-title">身長</span>
+        </div>
+        <div class="category-list">
+            <% User.height_ranges.each_key do |key| %>
+                <label class="category-chip">
+                    <%= f.radio_button :height_range, key, class: "category-checkbox" %>
+                    <span class="category-pill">
+                        <%= enum_display_name(@post, :height_range, key) %>
+                    </span>
+                </label>
+            <% end %>
+        </div>
+    </div>
+
     <div class="form-actions">
         <%= f.submit "投稿", class: "primary-button" %>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,10 @@ module Myapp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.i18n.default_locale = :ja
+
+    config.i18n.available_locales = [:ja, :en]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,31 @@
+ja:
+  activerecord:
+    attributes:
+      post:
+        style_category:
+          straight: "ストレート"
+          wave: "ウェーブ"
+          natural: "ナチュラル"
+        height_range:
+          under_150: "150㎝未満"
+          range_150_155: "150~155㎝"
+          range_155_160: "155~160㎝"
+          range_160_165: "160~165㎝"
+          range_165_170: "165~170㎝"
+          range_170_175: "170~175㎝"
+          range_175_180: "175~180㎝"
+          over_180: "180㎝以上"
+      user:
+        style_category:
+          straight: "ストレート"
+          wave: "ウェーブ"
+          natural: "ナチュラル"
+        height_range:
+          under_150: "150㎝未満"
+          range_150_155: "150~155㎝"
+          range_155_160: "155~160㎝"
+          range_160_165: "160~165㎝"
+          range_165_170: "165~170㎝"
+          range_170_175: "170~175㎝"
+          range_175_180: "175~180㎝"
+          over_180: "180㎝以上"

--- a/db/migrate/20250812011129_add_style_category_to_posts.rb
+++ b/db/migrate/20250812011129_add_style_category_to_posts.rb
@@ -1,0 +1,5 @@
+class AddStyleCategoryToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :style_category, :integer
+  end
+end

--- a/db/migrate/20250812014828_add_height_range_to_posts.rb
+++ b/db/migrate/20250812014828_add_height_range_to_posts.rb
@@ -1,0 +1,5 @@
+class AddHeightRangeToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :height_range, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_11_043740) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_12_014828) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_11_043740) do
     t.integer "brightness_level", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "style_category"
+    t.integer "height_range"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
新規投稿に・骨格・身長を選択できるように実装

Postsテーブルにカラムの追加
Postにenumを記述
　→既存の User の enum （straight:0, wave:1, natural:2）をそのまま使用

newアクション
 @post.style_category = current_user.style_category　で初期値を設定
ログインしているユーザーの骨格タイプが表示される
(ユーザー情報は未定義)